### PR TITLE
[RFR] Add white-space automatically when using widthOnly argument

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -51,9 +51,11 @@ Name | Description | Default
 `success` | callback when a resizing is successful
 `fail` | callback when a resizing is failed
 `complete` | callback when all elements are done
-`widthOnly` | only resizing for width restraint; to be used in conjunction with CSS `white-space: nowrap` applied to the container tag
+`widthOnly` | only resizing for width restraint
 `explicitWidth` | explicit width
 `explicitHeight` | explicit height
+
+**Notice:** using `widthOnly` property would automatically add a `white-space: nowrap` to the resized element.
 
 Help and Support
 ----------------

--- a/jquery.textfill.js
+++ b/jquery.textfill.js
@@ -119,13 +119,16 @@
       var WfontSize = _sizing('W', ourText, $.fn.width, maxWidth, maxHeight, maxWidth, minFontPixels, maxFontPixels);
 
       if (Opts.widthOnly) {
-        ourText.css('font-size', WfontSize);
+        ourText.css({
+            'font-size': WfontSize,
+            'white-space': 'nowrap'
+        });
       } else {
         ourText.css('font-size', Math.min(HfontSize, WfontSize));
       }
       _debug('Final: ' + ourText.css('font-size'));
 
-      if (ourText.width()  > maxWidth 
+      if (ourText.width()  > maxWidth
       || (ourText.height() > maxHeight && !Opts.widthOnly)
       ) {
         ourText.css('font-size', oldFontSize);


### PR DESCRIPTION
As I can't see any usecase on which we would want to enlarge text only horizontally keeping word wrap?
