### PR TITLE
Was fixed the object Height, Width

### DIFF
--- a/source/jquery.textfill.js
+++ b/source/jquery.textfill.js
@@ -201,8 +201,8 @@
 
 			// Will resize to this dimensions.
 			// Use explicit dimensions when specified
-			var maxHeight = Opts.explicitHeight || $(this).height();
-			var maxWidth  = Opts.explicitWidth  || $(this).width();
+			var maxHeight = Opts.explicitHeight || parseInt($(this).get(0).style.height);
+			var maxWidth  = Opts.explicitWidth  || parseInt($(this).get(0).style.width);
 
 			var oldFontSize = ourText.css('font-size');
 


### PR DESCRIPTION
Hi, I fixed a bug on object Height and Width. When I'm using JQuery UI Resazeble he set the end point 10 Pixel on Height when do you call $(this).heigth(); his answer is for example 100 which wrong; the bug come from JQuery but there is more complicated to fix end point. From my point of view is not Wrong if you will do the next update:

```
var maxHeight = Opts.explicitHeight || parseInt($(this).get(0).style.height);
```

   var maxWidth  = Opts.explicitWidth  || parseInt($(this).get(0).style.width);

it will solve the problem. try to do an test case using an container with some padding etc. 
