### PR TITLE
Use jQuery from node_modules version if available instead of using gl…

### DIFF
--- a/source/jquery.textfill.js
+++ b/source/jquery.textfill.js
@@ -320,5 +320,10 @@
 		return this;
 	};
 
-})(window.jQuery);
+})(function() {
+	if (typeof module !== 'undefined' && module.exports) {
+		return require('jquery');
+	}
+	return window.jQuery;
+}());
 


### PR DESCRIPTION
…obal version

This allows to use text-fill with tools like webpack or browserify where jquery might not be in window scope. 
