### PR TITLE
"widhtOnly" option needs to measure with "nowrap"

### DIFF
--- a/source/jquery.textfill.js
+++ b/source/jquery.textfill.js
@@ -149,6 +149,11 @@
 			//
 			//     http://stackoverflow.com/a/17433451/1094964
 			//
+			
+			if (Opts.widthOnly) {
+				// We need to measure with nowrap otherwise wrapping occurs and the measurement is wrong
+      				ourText.css('white-space', 'nowrap' );
+			}			
 
 			while (minFontPixels < (maxFontPixels - 1)) {
 


### PR DESCRIPTION
I had problems getting textfill to work with a headline which should adjust a single line.
Situation:

```
<div style="width: 700px">
  <h1><style>Some crazy good headline</style><h1>
</div>

<script type="text/javascript">
    jQuery('h1').textfill({
        widthOnly: true 
    });
</script>
```

After spending some time reading the code I noticed:
we need to measure with css "whitespace: nowrap" otherwise wrapping occurs and the measurement is wrong.