### PR TITLE
Bug fixed: _sizing function unexpected finish before find the best size

### DIFF
--- a/source/jquery.textfill.js
+++ b/source/jquery.textfill.js
@@ -158,7 +158,7 @@
 				if (curSize <= max) {
 					minFontPixels = fontSize;
 
-					if (curSize == max) {
+					if (curSize == max && (max == maxHeight || Opts.widthOnly)) {
 						break;
 					}
 				}


### PR DESCRIPTION
_sizing function should not be finished when **curSize == max** in case when **max == maxWidth**.

Text may wrap, so this is not sufficient condition.